### PR TITLE
Add .jira-dialog-content background

### DIFF
--- a/jira-full-dark.css
+++ b/jira-full-dark.css
@@ -309,7 +309,8 @@ form.aui optgroup option,
 .intform form,
 .screen-editor .available-fields,
 .tempo .tempo-stalker-content.stalker-content.issue-header-content .aui-page-header,
-.content-container {
+.content-container,
+.jira-dialog-content {
 	background: #303030 !important;
 	color: #999;
 }


### PR DESCRIPTION
The pop-up dialogs (f.e. "new issue") still had a white background.
This should fix that